### PR TITLE
Fix backdrop click + Add feature to close modal when press Esc key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Context to open and close the modal.
 - Support to `fullScreen` mode.
 - `scroll` and `showContentDividers` props.
+- Dismiss when press `Esc` key.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ WIP
 | `backdrop`| `ResponsiveValue<BackdropMode> | BackdropMode` | How the backdrop should be rendered | `'clickable'` |
 | `titleTag` | `TitleTag` | Which tag the title element should render | `'h3'` |
 | `fullScreen` | `ResponsiveValue<boolean> | boolean` | If the modal should be in full screen | `false` |
+| `disableEscapeKeyDown` | `boolean` | If if should disable closing the modal when you press `Esc` | `false` |
 
 You can learn more about `ResponsiveValue` in the documentation of [responsive-values](https://vtex.io/docs/app/vtex.responsive-values).
 

--- a/react/Modal.tsx
+++ b/react/Modal.tsx
@@ -25,7 +25,9 @@ interface Props {
   titleTag: TitleTag
   scroll?: ScrollMode
   blockClass?: string
+  children?: React.ReactNode
   showContentDividers: boolean
+  disableEscapeKeyDown?: boolean
   fullScreen?: MaybeResponsiveInput<boolean>
   backdrop?: MaybeResponsiveInput<BackdropMode>
   showCloseButton?: MaybeResponsiveInput<boolean>
@@ -35,13 +37,14 @@ const CSS_HANDLES = ['paper', 'topRow', 'container', 'closeButton']
 
 const responsiveProps = ['backdrop', 'fullScreen', 'showCloseButton'] as const
 
-const Modal: React.FC<Props> = props => {
+function Modal(props: Props) {
   const {
     title,
     titleTag,
     children,
     showContentDividers,
     scroll = ScrollMode.content,
+    disableEscapeKeyDown = false,
   } = props
 
   const {
@@ -100,36 +103,47 @@ const Modal: React.FC<Props> = props => {
       backdrop={backdrop}
       onClose={handleClose}
       onBackdropClick={handleBackdropClick}
+      disableEscapeKeyDown={disableEscapeKeyDown}
     >
-      {/* click-events-have-key-events is disabled because this will be handled by BaseModal */}
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
-      <div className={containerClasses} onClick={handleBackdropClick}>
-        <div className={paperClasses} style={styles.root}>
-          {(title || showCloseButton) && (
-            <div className={topRowClasses}>
-              {title && (
-                <ModalTitle
-                  className={showCloseButton ? '' : 'pr5'}
-                  tag={titleTag}
-                >
-                  {title}
-                </ModalTitle>
-              )}
-              {showCloseButton && (
-                <button
-                  onClick={handleClose}
-                  className={`${handles.closeButton} ma0 bg-transparent pointer bw0 pa2`}
-                >
-                  <IconClose size={24} type="line" />
-                </button>
-              )}
-            </div>
-          )}
-          <ModalContent dividers={showContentDividers}>{children}</ModalContent>
+      {
+        /* click-events-have-key-events is disabled because this will be handled by BaseModal */
+        /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+        <div
+          tabIndex={-1}
+          className={containerClasses}
+          onClick={handleBackdropClick}
+        >
+          <div className={paperClasses} style={styles.root}>
+            {(title || showCloseButton) && (
+              <div className={topRowClasses}>
+                {title && (
+                  <ModalTitle
+                    className={showCloseButton ? '' : 'pr5'}
+                    tag={titleTag}
+                  >
+                    {title}
+                  </ModalTitle>
+                )}
+                {showCloseButton && (
+                  <button
+                    onClick={handleClose}
+                    className={`${handles.closeButton} ma0 bg-transparent pointer bw0 pa2`}
+                  >
+                    <IconClose size={24} type="line" />
+                  </button>
+                )}
+              </div>
+            )}
+            <ModalContent dividers={showContentDividers}>
+              {children}
+            </ModalContent>
+          </div>
         </div>
-      </div>
+      }
     </BaseModal>
   )
 }
 
-export default Modal
+const ModalRef = React.forwardRef(Modal)
+
+export default ModalRef

--- a/react/Modal.tsx
+++ b/react/Modal.tsx
@@ -62,11 +62,18 @@ const Modal: React.FC<Props> = props => {
     }
   }
 
-  const handleBackdropClick = () => {
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    // Prevent clicking inside the modal and closing it
+    // this way it will close only if you click in the backdrop
+    if (e.target !== e.currentTarget) {
+      return
+    }
+
     if (backdrop === BackdropMode.clickable) {
       handleClose()
     }
   }
+
   const containerClasses = classnames(handles.container, 'outline-0 h-100', {
     ['overflow-y-auto overflow-x-hidden tc']: scroll === ScrollMode.body,
     ['flex items-center justify-center']: scroll === ScrollMode.content,
@@ -91,9 +98,12 @@ const Modal: React.FC<Props> = props => {
     <BaseModal
       open={open}
       backdrop={backdrop}
+      onClose={handleClose}
       onBackdropClick={handleBackdropClick}
     >
-      <div className={containerClasses}>
+      {/* click-events-have-key-events is disabled because this will be handled by BaseModal */}
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+      <div className={containerClasses} onClick={handleBackdropClick}>
         <div className={paperClasses} style={styles.root}>
           {(title || showCloseButton) && (
             <div className={topRowClasses}>

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -21,7 +21,9 @@ const ModalTrigger: React.FC<{}> = ({ children }) => {
   }
 
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
     <div
+      tabIndex={0}
       role="button"
       onClick={handleModalOpen}
       className={`${handles.triggerContainer} bg-transparent pa0 outline-0 bw0`}

--- a/react/components/BaseModal.tsx
+++ b/react/components/BaseModal.tsx
@@ -9,6 +9,7 @@ interface Props
     HTMLDivElement
   > {
   open: boolean
+  onClose?: () => void
   keepMounted?: boolean
   backdrop?: BackdropMode
   container?: ContainerType

--- a/react/components/BaseModal.tsx
+++ b/react/components/BaseModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import Portal, { ContainerType } from './Portal'
 import Backdrop, { BackdropMode } from './Backdrop'
+import TrapFocus from './TrapFocus'
 
 interface Props
   extends React.DetailedHTMLProps<
@@ -9,10 +10,12 @@ interface Props
     HTMLDivElement
   > {
   open: boolean
-  onClose?: () => void
+  onClose: () => void
   keepMounted?: boolean
   backdrop?: BackdropMode
   container?: ContainerType
+  disableEscapeKeyDown?: boolean
+  children: React.ReactElement
   onBackdropClick?: (e: React.MouseEvent<HTMLDivElement>) => void
 }
 
@@ -27,14 +30,16 @@ const styles: Record<string, React.CSSProperties> = {
   },
 } as const
 
-const BaseModal: React.FC<Props> = props => {
+export default function BaseModal(props: Props) {
   const {
     open,
+    onClose,
     backdrop,
     children,
     container,
     onBackdropClick,
     keepMounted = false,
+    disableEscapeKeyDown = false,
     ...rest
   } = props
 
@@ -55,6 +60,14 @@ const BaseModal: React.FC<Props> = props => {
     }
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Escape' || disableEscapeKeyDown) {
+      return
+    }
+    e.stopPropagation()
+    onClose()
+  }
+
   if (!keepMounted && !open) {
     return null
   }
@@ -66,8 +79,9 @@ const BaseModal: React.FC<Props> = props => {
         role="presentation"
         onClick={handleClick}
         style={styles.container}
+        onKeyDown={handleKeyDown}
       >
-        {children}
+        <TrapFocus open={open}>{children}</TrapFocus>
         {backdrop !== BackdropMode.none && (
           <Backdrop open={open} onClick={onBackdropClick} />
         )}
@@ -75,5 +89,3 @@ const BaseModal: React.FC<Props> = props => {
     </Portal>
   )
 }
-
-export default BaseModal

--- a/react/components/TrapFocus.tsx
+++ b/react/components/TrapFocus.tsx
@@ -1,0 +1,21 @@
+import React, { useRef, useEffect } from 'react'
+
+interface Props {
+  children: React.ReactElement
+  open: boolean
+}
+
+const TrapFocus: React.FC<Props> = props => {
+  const { children, open } = props
+  const childRef = useRef<HTMLElement>()
+
+  useEffect(() => {
+    if (open && childRef.current) {
+      childRef.current.focus()
+    }
+  }, [open])
+
+  return <>{React.cloneElement(children, { ref: childRef })}</>
+}
+
+export default TrapFocus


### PR DESCRIPTION
#### What problem is this solving?

Backdrop click was not working because in the previous PR I added a new div to wrap the paper of the Modal, now this is going to work + gonna be easy to add the scape feature. Also, there is no changelog since this is a fix of something that wasn't launched yet.

#### How should this be manually tested?

[Workspace](https://modallayout--storecomponents.myvtex.com/)

To test the Esc feature you have two modals, the first rich text opens a modal that has `disableEscapeKeyDown` as `true`, the second one has as `false`

![image](https://user-images.githubusercontent.com/8517023/71365514-fe8cc700-257d-11ea-836a-31ee5763faa0.png)


#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
