### PR TITLE
Fix modal blocking the anchor elements with target blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Not being able to create links with `target="_blank"` inside of the modals.
 
 ## [0.1.0] - 2020-01-30
 ### Changed

--- a/react/BaseModal.tsx
+++ b/react/BaseModal.tsx
@@ -98,7 +98,6 @@ export default function BaseModal(props: Props) {
   }, [setExited])
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.preventDefault()
     e.stopPropagation()
 
     if (rest.onClick) {


### PR DESCRIPTION
#### What problem is this solving?

If you try to add a link inside of a modal that has `target="_blank"` it would do anything when you click because the modal was calling `preventDefault` of the event

#### How should this be manually tested?

1. Go to the [workspace](https://quickview--storecomponents.myvtex.com/)
2. Open the quickview
3. click in a link

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
