### PR TITLE
Update ModelContext to also export ModelContextProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Export component `ModelContextProvider` in `ModelContext` entrypoint.
+
+### Fixed
+- Backdrop not working if component is used directly (not using blocks).
 
 ## [0.5.1] - 2020-06-10
 ### Fixed

--- a/react/ModalContext.ts
+++ b/react/ModalContext.ts
@@ -1,3 +1,6 @@
-import { useModalDispatch } from './components/ModalContext'
+import {
+  useModalDispatch,
+  ModalContextProvider,
+} from './components/ModalContext'
 
-export default { useModalDispatch }
+export default { useModalDispatch, ModalContextProvider }

--- a/react/components/Backdrop.tsx
+++ b/react/components/Backdrop.tsx
@@ -3,6 +3,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { TransitionProps } from 'react-transition-group/Transition'
 
 import Fade from './Animations/Fade'
+import styles from '../styles.css'
 
 export enum BackdropMode {
   display = 'display',
@@ -31,7 +32,7 @@ const Backdrop: React.FC<Props> = props => {
   return (
     <Fade in={open} timeout={transitionDuration}>
       <div
-        className={handles.backdropContainer}
+        className={`${handles.backdropContainer} ${styles.backdropContainer}`}
         data-testid="modal-backdrop-container"
       >
         <div

--- a/react/components/ModalContext.tsx
+++ b/react/components/ModalContext.tsx
@@ -56,8 +56,18 @@ function modalContextReducer(state: State = DEFAULT_STATE, action: Action) {
   }
 }
 
-export const ModalContextProvider: React.FC = ({ children }) => {
-  const [state, dispatch] = useReducer(modalContextReducer, DEFAULT_STATE)
+interface ContextProviderProps {
+  initialState?: State
+}
+
+export const ModalContextProvider: React.FC<ContextProviderProps> = ({
+  children,
+  initialState = undefined,
+}) => {
+  const [state, dispatch] = useReducer(
+    modalContextReducer,
+    initialState ?? DEFAULT_STATE
+  )
 
   return (
     <ModalStateContext.Provider value={state}>


### PR DESCRIPTION
#### What problem is this solving?

I want to open the modal programatically, from anywhere inside the Checkout (the trigger wasn't enough) so I need to wrap my components using the context provider for the `Modal` component. This PR also fixes an issue seen with the styles for the `Backdrop` not being applied if the component is used directly instead of the blocks API.

#### How to test it?

[Workspace](https://sndpurchase--checkoutio.myvtex.com/cart/add?sku=289&qty=1&seller=1).

This workspace is still WIP but you can see the modal by following these steps:

1. Click the "proceed to checkout" button.
2. Enter the email `lucas.brito@vtex.com.br`.
3. Click the button to edit the profile.

The modal should appear.

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/10223856/85176002-2c15ad00-b24f-11ea-89d8-fd4c6d66f227.png)


#### Describe alternatives you've considered, if any.

I considered using the `ModalTrigger` component, but it made the whole checkout "clickable", and I wanted a programatic way to open the modal instead of the component handling it for me.