### PR TITLE
Remove feature to close the modal when the back button of browser is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Modal changing the behavior of the back button.
+
+### Removed
+- Feature to close the modal when the back button is clicked.
 
 ## [0.5.1] - 2020-06-10
 ### Fixed

--- a/react/modules/ModalManager.ts
+++ b/react/modules/ModalManager.ts
@@ -29,8 +29,6 @@ function isOverflowing(container: HTMLElement) {
   return container.scrollHeight > container.clientHeight
 }
 
-const hashRegex = /#$/
-
 interface RestoreStyle {
   value: string
   el: HTMLElement
@@ -114,19 +112,6 @@ export default class ModalManager {
     this.modals = []
     this.closeMethods = []
     this.containers = []
-
-    if (window?.addEventListener) {
-      window.addEventListener('popstate', e => {
-        // If this event if fired with a modal open it will close it
-        if (this.closeMethods.length === 0) {
-          return
-        }
-
-        e.stopPropagation()
-        this.closeMethods[this.closeMethods.length - 1]()
-        this.removeTopModal()
-      })
-    }
   }
 
   public add(modal: ModalRef, container: HTMLElement, onClose: OnClose) {
@@ -166,11 +151,6 @@ export default class ModalManager {
     if (!containerInfo.restore) {
       containerInfo.restore = handleContainer(containerInfo)
     }
-
-    // If this is the first modal to be opened, it has to push to the state
-    if (this.modals.length === 1) {
-      window?.history.pushState({ type: 'OPEN_MODAL' }, 'open modal', '#')
-    }
   }
 
   public remove(modal: ModalRef) {
@@ -195,14 +175,6 @@ export default class ModalManager {
       }
 
       this.containers.splice(containerIndex, 1)
-    }
-
-    if (this.modals.length === 0) {
-      window?.history.replaceState(
-        { type: 'CLOSE_MODAL' },
-        'close modal',
-        window.location.href.replace(hashRegex, '')
-      )
     }
 
     return modalIndex


### PR DESCRIPTION
#### What problem is this solving?

Back button of the browser not working because of the state that the modal was putting in history.

This is kinda breaking change, but since there is no prop to this feature, I think its ok to turn it off

#### How to test it?

1. [Workspace](https://modalback--storecomponents.myvtex.com/)
2. Open the modal clicking in the quickview button
3. Close the modal
4.  Go to a product page
5. Click in the back button

[Do the same in the master to see the problem](https://storecomponents.myvtex.com/)

You can test in the equishopper as well clicking in the quickview of the products
[equishopper with the fix](https://modalback--equishopper.myvtex.com/)
[equishopper with the problem](https://equishopper.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

* Instead of using `pushState` using `replaceState` when a modal is opened, but it had the same problem
* Removing the `stopPropagation` of `popstate` event callback
* Removing the `popstate` callback
* Calling `window.history.back()` when removing the modal, but doesn't work all the time and sometimes it scrolls back to the top of the page after closing the modal

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/9Y5BbDSkSTiY8/giphy.gif)
