### PR TITLE
Add 'customPixelEventId' prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `customEventId` to `modal-trigger` block.
+- `customPixelEventId` to `modal-trigger` block.
 
 ## [0.6.1] - 2020-07-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customEventId` to `modal-trigger` block.
 
 ## [0.6.1] - 2020-07-08
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 | --- | --- | --- | --- |
 | `trigger` | `enum` | Whether the Modal content should be triggered by user click ( `click`), when the page is fully loaded (`load`) or when the page is fully loaded but the modal will appears just once per session (`load-session`). | `click` |
 | `customPixelEventId` | `string`  | Store event ID responsible for triggering the `modal-trigger` block (hence triggering the opening of `modal-layout` blocks on the interface as well). | `undefined`    |
+| `customPixelEventName` | `string`                                                                   | Store event name responsible for triggering the `modal-trigger` block (hence triggering the opening of `modal-layout` blocks on the interface as well). Some examples are: `'addToCart'` and `'removeFromCart'` events. Notice that using this prop will make the associated `modal-layout` open in **every** event with the specified name if no `customPixelEventId` is specified. | `undefined`    |
 
 ### `modal-layout` props
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,13 +75,14 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 }
 ```
 
-*In the example above, the [Rich Text](https://vtex.io/docs/components/all/vtex.rich-text/) block renders the `Click me` text that will trigger the Modal content when clicked on. The modal content, in turn, is defined by the `modal-layout` block. According to the example above, the Modal content triggered by the `Click me` Rich Text would be a `Hello` text.* 
+*In the example above, the [Rich Text](https://vtex.io/docs/components/all/vtex.rich-text/) block renders the `Click me` text that will trigger the Modal content when clicked on. The modal content, in turn, is defined by the `modal-layout` block. According to the example above, the Modal content triggered by the `Click me` Rich Text would be a `Hello` text.*
 
-### `modal-trigger` props 
+### `modal-trigger` props
 
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
 | `trigger` | `enum` | Whether the Modal content should be triggered by user click ( `click`), when the page is fully loaded (`load`) or when the page is fully loaded but the modal will appears just once per session (`load-session`). | `click` |
+| `customPixelEventId` | `string`                                                                   | Define the `id` of the event that will be listened to by the `modal-trigger` to open its associated `modal-layout`. | `undefined`    |
 
 ### `modal-layout` props
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
 | `trigger` | `enum` | Whether the Modal content should be triggered by user click ( `click`), when the page is fully loaded (`load`) or when the page is fully loaded but the modal will appears just once per session (`load-session`). | `click` |
-| `customPixelEventId` | `string`                                                                   | Define the `id` of the event that will be listened to by the `modal-trigger` to open its associated `modal-layout`. | `undefined`    |
+| `customPixelEventId` | `string`  | Store event ID responsible for triggering the `modal-trigger` block (hence triggering the opening of `modal-layout` blocks on the interface as well). | `undefined`    |
 
 ### `modal-layout` props
 

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
     "vtex.css-handles": "0.x",
     "vtex.store-icons": "0.x",
     "vtex.responsive-values": "0.x",
-    "vtex.native-types": "0.x"
+    "vtex.native-types": "0.x",
+    "vtex.pixel-manager": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
-import { useCustomEvents } from 'vtex.pixel-manager'
+import { usePixelEventCallback } from 'vtex.pixel-manager'
 
 import {
   useModalDispatch,
@@ -27,7 +27,7 @@ const ModalTrigger: React.FC<Props> = props => {
   const handles = useCssHandles(CSS_HANDLES)
   const [openOnLoad, setOpenOnLoad] = useState(false)
 
-  useCustomEvents(customEventId, () => {
+  usePixelEventCallback(customEventId, () => {
     dispatch({ type: 'OPEN_MODAL' })
   })
 

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 import { usePixelEventCallback } from 'vtex.pixel-manager'
+import { PixelData } from 'vtex.pixel-manager/react/PixelContext'
 
 import {
   useModalDispatch,
@@ -19,16 +20,26 @@ enum TriggerMode {
 interface Props {
   trigger?: TriggerMode
   customPixelEventId?: string
+  customPixelEventName?: PixelData['event']
 }
 
 const ModalTrigger: React.FC<Props> = props => {
-  const { children, trigger = TriggerMode.click, customPixelEventId } = props
+  const {
+    children,
+    trigger = TriggerMode.click,
+    customPixelEventId,
+    customPixelEventName,
+  } = props
   const dispatch = useModalDispatch()
   const handles = useCssHandles(CSS_HANDLES)
   const [openOnLoad, setOpenOnLoad] = useState(false)
 
-  usePixelEventCallback(customPixelEventId, () => {
-    dispatch({ type: 'OPEN_MODAL' })
+  usePixelEventCallback({
+    eventId: customPixelEventId,
+    eventName: customPixelEventName,
+    handler: () => {
+      dispatch({ type: 'OPEN_MODAL' })
+    },
   })
 
   const handleModalOpen = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -18,16 +18,16 @@ enum TriggerMode {
 
 interface Props {
   trigger?: TriggerMode
-  customEventId?: string
+  customPixelEventId?: string
 }
 
 const ModalTrigger: React.FC<Props> = props => {
-  const { children, trigger = TriggerMode.click, customEventId } = props
+  const { children, trigger = TriggerMode.click, customPixelEventId } = props
   const dispatch = useModalDispatch()
   const handles = useCssHandles(CSS_HANDLES)
   const [openOnLoad, setOpenOnLoad] = useState(false)
 
-  usePixelEventCallback(customEventId, () => {
+  usePixelEventCallback(customPixelEventId, () => {
     dispatch({ type: 'OPEN_MODAL' })
   })
 

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
+import { useCustomEvents } from 'vtex.pixel-manager'
 
 import {
   useModalDispatch,
@@ -12,17 +13,23 @@ enum TriggerMode {
   click = 'click',
   load = 'load',
   loadSession = 'load-session',
+  event = 'event',
 }
 
 interface Props {
   trigger?: TriggerMode
+  customEventId?: string
 }
 
 const ModalTrigger: React.FC<Props> = props => {
-  const { children, trigger = TriggerMode.click } = props
+  const { children, trigger = TriggerMode.click, customEventId } = props
   const dispatch = useModalDispatch()
   const handles = useCssHandles(CSS_HANDLES)
   const [openOnLoad, setOpenOnLoad] = useState(false)
+
+  useCustomEvents(customEventId, () => {
+    dispatch({ type: 'OPEN_MODAL' })
+  })
 
   const handleModalOpen = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault()

--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,7 @@
     "typescript": "3.8.3",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
-    "vtex.pixel-manager": "https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager",
+    "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager",
     "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -19,8 +19,10 @@
     "@types/react-transition-group": "^4.2.3",
     "@vtex/test-tools": "^1.1.0",
     "typescript": "3.8.3",
-    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
+    "vtex.pixel-manager": "https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager",
+    "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons"
   },
   "version": "0.6.1"

--- a/react/typings/vtex.pixel-manager.d.ts
+++ b/react/typings/vtex.pixel-manager.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.pixel-manager'

--- a/react/typings/vtex.pixel-manager.d.ts
+++ b/react/typings/vtex.pixel-manager.d.ts
@@ -1,1 +1,0 @@
-declare module 'vtex.pixel-manager'

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4755,9 +4755,9 @@ verror@1.10.0:
   version "0.7.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
 
-"vtex.pixel-manager@https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager":
-  version "1.2.0"
-  resolved "https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager#d7ceb1482b8a1f57d2998f5436f827eddadc41ec"
+"vtex.pixel-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager":
+  version "1.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager#84e731e138aa3aaf98dd519e5cff929cdf3745d8"
 
 "vtex.responsive-values@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react":
   version "0.0.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4747,13 +4747,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
-  version "0.4.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles#62ee61d1bb9efdc919e5cf4bb44fabcf9050d255"
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
+  version "0.4.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime":
-  version "8.100.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime#b94c966be2d1c3d8bc9f1caf2dd9f462d88e98d2"
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types":
+  version "0.7.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
+
+"vtex.pixel-manager@https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager":
+  version "1.2.0"
+  resolved "https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager#d7ceb1482b8a1f57d2998f5436f827eddadc41ec"
+
+"vtex.responsive-values@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
 "vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons":
   version "0.17.0"


### PR DESCRIPTION
#### What problem is this solving?

This enables users to trigger `modal-layout`s to open due to events with `eventId === customPixelEventId`.

By doing that, we can achieve behaviors such as opening a confirmation `modal` when a customer adds an item to the cart.

#### How to test it?

Go to this [Workspace](https://customevents--storecomponents.myvtex.com/) and 

#### Related to / Depends on

Depends on: https://github.com/vtex/pixel-manager/pull/29.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/McVdbhbPdTZEEDaT7P/giphy.gif)