### PR TITLE
Adding new Prop to close modal when url has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Adding a new prop to close modal when url has changed
 
 ## [0.7.1] - 2020-09-15
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 | `disableEscapeKeyDown` | `boolean` | Whether the modal should be closed when pressing the `Esc` key (`true`) or not (`false`). | `false` | 
 | `fullScreen` | `boolean` | Whether the modal should fill the whole screen (`true`) or not (`false`). This prop is responsive i.e. it adapts itself to the device's breakpoints.  | `false` | 
 | `backdrop` | `enum` | Whether the modal will have a clickable backdrop (`clickable`) or no backdrop at all (`none`). This prop is responsive i.e. it adapts itself to the device's breakpoints. | `clickable` | 
+| `closeModalWhenUrlChange` | `boolean` | If you want your modal to close when the url updates, just set the value of `closeModalWhenUrlChange` to true
 
 ### `modal-header` props 
 

--- a/react/package.json
+++ b/react/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^16.9.2",
     "@types/react-transition-group": "^4.2.3",
     "@vtex/test-tools": "^1.1.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
     "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4768,12 +4768,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.3.3333:
+typescript@3.9.7, typescript@^3.3.3333:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What problem is this solving?

Solves the problem of the open modal when the url is updated

<!--- What is the motivation and context for this change? -->

#### How to test it?

You can see in my example that when you click on a link the modal closes

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://mcdon28--devmcdbrdeliveryio.myvtex.com/catalog)

#### Screenshots or example usage:

First step adding prop on modal-layout

![image](https://user-images.githubusercontent.com/38354801/100373167-1d46d980-2fe9-11eb-960c-44251790db81.png)

Later open modal 

![image](https://user-images.githubusercontent.com/38354801/100373235-36e82100-2fe9-11eb-9721-c8e2c42c049f.png)
 
and finnaly click to your option

![image](https://user-images.githubusercontent.com/38354801/100373319-5bdc9400-2fe9-11eb-8e1e-fddb8b6746b9.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

Happy to be able to create new things

![happy](https://media.giphy.com/media/5iXTLFjce2qcw/giphy.gif)
