### PR TITLE
Bugfix/close modal when update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 
-- Adding a new prop to close modal when url has changed
+- Open modal bug when changing url
 
 ## [0.7.2] - 2020-12-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-
-- Open modal bug when changing url
+### Fixed
+- Close modal when the URL changes.
 
 ## [0.7.2] - 2020-12-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Adding a new prop to close modal when url has changed
 
 ## [0.7.2] - 2020-12-01
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 | `disableEscapeKeyDown` | `boolean` | Whether the modal should be closed when pressing the `Esc` key (`true`) or not (`false`). | `false` | 
 | `fullScreen` | `boolean` | Whether the modal should fill the whole screen (`true`) or not (`false`). This prop is responsive i.e. it adapts itself to the device's breakpoints.  | `false` | 
 | `backdrop` | `enum` | Whether the modal will have a clickable backdrop (`clickable`) or no backdrop at all (`none`). This prop is responsive i.e. it adapts itself to the device's breakpoints. | `clickable` | 
-| `closeModalWhenUrlChange` | `boolean` | If you want your modal to close when the url updates, just set the value of `closeModalWhenUrlChange` to true
+
 
 ### `modal-header` props 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 | `disableEscapeKeyDown` | `boolean` | Whether the modal should be closed when pressing the `Esc` key (`true`) or not (`false`). | `false` | 
 | `fullScreen` | `boolean` | Whether the modal should fill the whole screen (`true`) or not (`false`). This prop is responsive i.e. it adapts itself to the device's breakpoints.  | `false` | 
 | `backdrop` | `enum` | Whether the modal will have a clickable backdrop (`clickable`) or no backdrop at all (`none`). This prop is responsive i.e. it adapts itself to the device's breakpoints. | `clickable` | 
+| `closeModalWhenUrlChange` | `boolean` | If you want your modal to close when the url updates, just set the value of `closeModalWhenUrlChange` to true
 
 ### `modal-header` props 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,6 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 | `fullScreen` | `boolean` | Whether the modal should fill the whole screen (`true`) or not (`false`). This prop is responsive i.e. it adapts itself to the device's breakpoints.  | `false` | 
 | `backdrop` | `enum` | Whether the modal will have a clickable backdrop (`clickable`) or no backdrop at all (`none`). This prop is responsive i.e. it adapts itself to the device's breakpoints. | `clickable` | 
 
-
 ### `modal-header` props 
 
 | Prop name | Type | Description | Default value |

--- a/react/Modal.tsx
+++ b/react/Modal.tsx
@@ -23,7 +23,6 @@ interface Props {
   disableEscapeKeyDown?: boolean
   fullScreen?: MaybeResponsiveInput<boolean>
   backdrop?: MaybeResponsiveInput<BackdropMode>
-  closeModalWhenUrlChange?: boolean
 }
 
 const CSS_HANDLES = ['paper', 'topRow', 'container', 'closeButton'] as const
@@ -31,12 +30,7 @@ const CSS_HANDLES = ['paper', 'topRow', 'container', 'closeButton'] as const
 const responsiveProps = ['backdrop', 'fullScreen', 'showCloseButton'] as const
 
 function Modal(props: Props) {
-  const {
-    children,
-    scroll = 'content',
-    disableEscapeKeyDown = false,
-    closeModalWhenUrlChange = false,
-  } = props
+  const { children, scroll = 'content', disableEscapeKeyDown = false } = props
 
   const { fullScreen = false, backdrop = 'clickable' } = useResponsiveValues(
     pick(responsiveProps, props)
@@ -65,12 +59,10 @@ function Modal(props: Props) {
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
-    if (closeModalWhenUrlChange === true) {
-      dispatch({
-        type: 'CLOSE_MODAL',
-      })
-    }
-  }, [pathname, dispatch, closeModalWhenUrlChange])
+    dispatch({
+      type: 'CLOSE_MODAL',
+    })
+  }, [pathname, dispatch])
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     // Prevent clicking inside the modal and closing it

--- a/react/Modal.tsx
+++ b/react/Modal.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import classnames from 'classnames'
 import { useCssHandles } from 'vtex.css-handles'
 import {
   useResponsiveValues,
   MaybeResponsiveInput,
 } from 'vtex.responsive-values'
-import { useRuntime } from 'vtex.render-runtime'
 
 import pick from './modules/pick'
 import styles from './styles.css'
@@ -13,6 +12,7 @@ import BaseModal from './BaseModal'
 import Fade from './components/Animations/Fade'
 import { BackdropMode } from './components/Backdrop'
 import { useModalState, useModalDispatch } from './components/ModalContext'
+import { useUrlChange } from './modules/useUrlChange'
 
 export type ScrollMode = 'body' | 'content'
 
@@ -39,15 +39,6 @@ function Modal(props: Props) {
   const handles = useCssHandles(CSS_HANDLES)
   const { open } = useModalState()
   const dispatch = useModalDispatch()
-  const { history } = useRuntime()
-
-  if (!history?.location?.pathname) {
-    return null
-  }
-
-  const {
-    location: { pathname },
-  } = history
 
   const handleClose = () => {
     if (dispatch) {
@@ -57,12 +48,18 @@ function Modal(props: Props) {
     }
   }
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  useEffect(() => {
-    dispatch({
-      type: 'CLOSE_MODAL',
-    })
-  }, [pathname, dispatch])
+  // Close modal when url changes
+  useUrlChange(
+    {
+      fn: () => {
+        dispatch({
+          type: 'CLOSE_MODAL',
+        })
+      },
+      skip: !open,
+    },
+    [open, dispatch]
+  )
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     // Prevent clicking inside the modal and closing it

--- a/react/modules/useUrlChange.ts
+++ b/react/modules/useUrlChange.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect } from 'react'
+import { useRuntime } from 'vtex.render-runtime'
+import { Listener } from 'history'
+
+type Params = {
+  fn: Listener
+  skip: boolean
+}
+
+export const useUrlChange = ({ fn, skip }: Params, deps: unknown[]) => {
+  const { history } = useRuntime()
+
+  // Lint is not getting it
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const memoizedCallback = useCallback(fn, deps)
+
+  useEffect(() => {
+    if (skip) return
+
+    // cancel method is returned to be executed whenever our deps change
+    return history?.listen(memoizedCallback)
+  }, [skip, memoizedCallback, history])
+}

--- a/react/package.json
+++ b/react/package.json
@@ -18,12 +18,14 @@
     "@types/react": "^16.9.2",
     "@types/react-transition-group": "^4.2.3",
     "@vtex/test-tools": "^1.1.0",
+    "history": "5",
     "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
-    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
-    "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.4/public/@types/vtex.native-types",
+    "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.4.0/public/@types/vtex.pixel-manager",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4-beta.1/public/@types/vtex.render-runtime",
     "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react",
-    "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons"
+    "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons"
   },
   "version": "0.7.2"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -924,6 +924,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.6":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -2660,6 +2667,13 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+history@5:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
+  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
 
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -4882,21 +4896,25 @@ verror@1.10.0:
   version "0.4.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types":
-  version "0.7.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.4/public/@types/vtex.native-types":
+  version "0.7.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.4/public/@types/vtex.native-types#336572ff607405761beaea01f408c56125dcd09d"
 
-"vtex.pixel-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager":
-  version "1.3.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager#84e731e138aa3aaf98dd519e5cff929cdf3745d8"
+"vtex.pixel-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.4.0/public/@types/vtex.pixel-manager":
+  version "1.4.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.4.0/public/@types/vtex.pixel-manager#f636047e354d65f4d7691c81e799c6458407bec0"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4-beta.1/public/@types/vtex.render-runtime":
+  version "8.126.4-beta.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4-beta.1/public/@types/vtex.render-runtime#27e35991b2f5ebb376056584eda9ff3a88a5faf1"
 
 "vtex.responsive-values@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react":
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons":
-  version "0.17.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons#1da7ec2f89522d8c5ed3418fec8fbc82817499db"
+"vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons":
+  version "0.18.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons#0ee94d549aa283ce3a13ab987c13eac4fdfd1bba"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
#### What problem is this solving?

Before this adjustment, the modal did not close when the url changed

<!--- What is the motivation and context for this change? -->

#### How to test it?

You can see in my example that when you click on a link the modal closes

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://mcdon28--devmcdbrdeliveryio.myvtex.com/catalog)

#### Screenshots or example usage:

Use the CEP: 01020-000

First step open modal 

![image](https://user-images.githubusercontent.com/38354801/100373235-36e82100-2fe9-11eb-9721-c8e2c42c049f.png)
 
and finnaly click to your option

![image](https://user-images.githubusercontent.com/38354801/100373319-5bdc9400-2fe9-11eb-8e1e-fddb8b6746b9.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

Happy to be able to create new things

![happy](https://media.giphy.com/media/5iXTLFjce2qcw/giphy.gif)
