### PR TITLE
Feature/event product overlay

### DIFF
--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useLayoutEffect } from 'react'
 import type { ReactNode } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
 import { usePixelEventCallback } from 'vtex.pixel-manager'
 import type { PixelEventTypes } from 'vtex.pixel-manager'
+import { usePixel } from 'vtex.pixel-manager/PixelContext'
 
 import {
   useModalDispatch,
@@ -34,6 +35,7 @@ function ModalTrigger(props: Props) {
   const dispatch = useModalDispatch()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
   const [openOnLoad, setOpenOnLoad] = useState(false)
+  const { push } = usePixel()
 
   usePixelEventCallback({
     eventId: customPixelEventId,
@@ -42,6 +44,15 @@ function ModalTrigger(props: Props) {
       dispatch({ type: 'OPEN_MODAL' })
     },
   })
+
+  //
+  useLayoutEffect(() => {
+    push({
+      event: 'vtex:quickViewProductOverlay',
+      items: [product],
+    })
+  })
+
 
   useEffect(() => {
     if (openOnLoad || !dispatch) {

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -45,7 +45,7 @@ function ModalTrigger(props: Props) {
     },
   })
 
-  //
+  //Add NewEvent ProductOverlay
   useLayoutEffect(() => {
     push({
       event: 'vtex:quickViewProductOverlay',

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -45,7 +45,6 @@ function ModalTrigger(props: Props) {
     },
   })
 
-  //Add NewEvent ProductOverlay
   useLayoutEffect(() => {
     push({
       event: 'vtex:quickViewProductOverlay',


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This change would be so that, when clicking on the button, he could fire the quickViewProductOverlay event.

#### How to test it?
To test just click on the add button, which will open a modal, with the description of the selected product.

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
[Workspace](https://icp303--modeloramamx.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
