### PR TITLE
Custom pixel event to modal-layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `customPixelEventId` to `modal-layout` block.
+
 ## [0.10.0] - 2021-04-22
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,8 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 | `disableEscapeKeyDown` | `boolean` | Whether the modal should be closed when pressing the `Esc` key (`true`) or not (`false`). | `false` | 
 | `fullScreen` | `boolean` | Whether the modal should fill the whole screen (`true`) or not (`false`). This prop is responsive i.e. it adapts itself to the device's breakpoints.  | `false` | 
 | `backdrop` | `enum` | Whether the modal will have a clickable backdrop (`clickable`) or no backdrop at all (`none`). This prop is responsive i.e. it adapts itself to the device's breakpoints. | `clickable` | 
-
+| `customPixelEventId` | `string`  | Store event ID responsible for triggering the `modal-layout` block (hence triggering the closing of `modal-layout` blocks on the interface as well). | `undefined`    |
+| `customPixelEventName` | `string`                                                                   | Store event name responsible for triggering the `modal-layout` block (hence triggering the closing of `modal-layout` blocks on the interface as well). Some examples are: `'addToCart'` and `'removeFromCart'` events. Notice that using this prop will make the associated `modal-layout` close in **every** event with the specified name if no `customPixelEventId` is specified. | `undefined`    |
 ### `modal-header` props 
 
 | Prop name | Type | Description | Default value |

--- a/react/Modal.tsx
+++ b/react/Modal.tsx
@@ -5,6 +5,8 @@ import type { CssHandlesTypes } from 'vtex.css-handles'
 import { useCssHandles } from 'vtex.css-handles'
 import type { ResponsiveValuesTypes } from 'vtex.responsive-values'
 import { useResponsiveValues } from 'vtex.responsive-values'
+import { usePixelEventCallback } from 'vtex.pixel-manager'
+import type { PixelEventTypes } from 'vtex.pixel-manager'
 
 import styles from './styles.css'
 import BaseModal, { CSS_HANDLES as BaseModalCssHandles } from './BaseModal'
@@ -28,6 +30,8 @@ interface Props {
   scroll?: ScrollMode
   blockClass?: string
   disableEscapeKeyDown?: boolean
+  customPixelEventId?: string
+  customPixelEventName?: PixelEventTypes.PixelData['event']
   fullScreen?: ResponsiveValuesTypes.ResponsiveValue<boolean>
   backdrop?: ResponsiveValuesTypes.ResponsiveValue<BackdropMode>
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
@@ -38,6 +42,8 @@ function Modal(props: PropsWithChildren<Props>) {
     children,
     classes,
     scroll = 'content',
+    customPixelEventId,
+    customPixelEventName,
     disableEscapeKeyDown = false,
   } = props
 
@@ -49,6 +55,14 @@ function Modal(props: PropsWithChildren<Props>) {
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
   const { open } = useModalState()
   const dispatch = useModalDispatch()
+
+  usePixelEventCallback({
+    eventId: customPixelEventId,
+    eventName: customPixelEventName,
+    handler: () => {
+      dispatch({ type: 'CLOSE_MODAL' })
+    },
+  })
 
   const handleClose = () => {
     if (dispatch) {


### PR DESCRIPTION
#### What problem is this solving?

Even though the [documentation](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-using-events-to-trigger-side-effects-on-store-components) states that the `modal-layout` possess the ability to trigger custom pixel events, the actual block doesn't have the props available.

Right now, the only one applicable is the `modal-trigger`, which triggers the action `OPEN_MODAL`.

We added the missing part.

#### How to test it?

[Workspace](https://sanz--arcaplanet.myvtex.com/prodotti-per-cani/cibo-per-cani/cibo-secco)

On any `product-summary` you will find, below their images, a modal-trigger that opens a product's quick view.
Click on `ACQUISTA`, this will add the product to the cart and close the corresponding modal.

#### Screenshots or example usage:

![Quickview](https://user-images.githubusercontent.com/50715158/130477277-ab85fb40-0b31-45ef-813c-46a8f4d00a87.png)
![Minicart](https://user-images.githubusercontent.com/50715158/130477282-ee9a7b4a-f60e-4af5-95bd-0df99ee8f892.png)

#### How does this PR make you feel? 

![](https://media.giphy.com/media/R7m04yMaGWVeE/giphy.gif?cid=ecf05e4707giamvybpd60j7mfa16eiqvs5mr3j0ck9k5urvj&rid=giphy.gif&ct=g)
