### PR TITLE
Added triggerDelay prop and a new trigger enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.14.0] - 2022-10-11
+
+### Added
+- *load-local* enum for **trigger** prop in order to do the same thing done with *load-session* but using localStorage.
+- **triggerDelay** prop in order to delay the Modal content trigger (useful for '*load*','*load-session*' and '*load-local*' if you want to show the modal after some time expressed in milliseconds. Not useful on '*click*').
+
 ## [0.13.0] - 2022-03-09
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,8 @@ Now, you are able to use all blocks exported by the `modal-layout` app. Check ou
 
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
-| `trigger` | `enum` | Whether the Modal content should be triggered by user click ( `click`), when the page is fully loaded (`load`) or when the page is fully loaded but the modal will appears just once per session (`load-session`). | `click` |
+| `trigger` | `enum` | Whether the Modal content should be triggered by user click ( `click`), when the page is fully loaded (`load`), when the page is fully loaded but the modal will appears just once per session (`load-session`) or when the page is fully loaded but the modal will appears just if it doesn't appeared yet for this reason a value in localStorage will be checked (`load-local`). | `click` |
+| `triggerDelay` | `number` | Whether the Modal content should be triggered after some time (time expressed in milliseconds, this prop is useful if you trigger the Modal content on `load` or `load-session` or `load-local`). | `undefined` |
 | `customPixelEventId` | `string`  | Store event ID responsible for triggering the `modal-trigger` block (hence triggering the opening of `modal-layout` blocks on the interface as well). | `undefined`    |
 | `customPixelEventName` | `string`                                                                   | Store event name responsible for triggering the `modal-trigger` block (hence triggering the opening of `modal-layout` blocks on the interface as well). Some examples are: `'addToCart'` and `'removeFromCart'` events. Notice that using this prop will make the associated `modal-layout` open in **every** event with the specified name if no `customPixelEventId` is specified. | `undefined`    |
 

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -12,10 +12,11 @@ import {
 
 const CSS_HANDLES = ['triggerContainer'] as const
 
-type TriggerMode = 'click' | 'load' | 'load-session' | 'event'
+type TriggerMode = 'click' | 'load' | 'load-session' | 'load-local' | 'event'
 
 interface Props {
   trigger?: TriggerMode
+  triggerDelay?: number
   customPixelEventId?: string
   customPixelEventName?: PixelEventTypes.PixelData['event']
   children: ReactNode
@@ -26,6 +27,7 @@ function ModalTrigger(props: Props) {
   const {
     children,
     trigger = 'click',
+    triggerDelay,
     customPixelEventId,
     customPixelEventName,
     classes,
@@ -56,12 +58,28 @@ function ModalTrigger(props: Props) {
       sessionStorage.setItem('hasOpenedModal', 'true')
     }
 
-    if (trigger !== 'load-session' && trigger !== 'load') {
+    if (trigger === 'load-local') {
+      if (localStorage.getItem('hasOpenedModal') === 'true') {
+        return
+      }
+
+      localStorage.setItem('hasOpenedModal', 'true')
+    }
+
+    if (trigger !== 'load-session' && trigger !== 'load-local' && trigger !== 'load') {
       return
     }
 
-    dispatch({ type: 'OPEN_MODAL' })
-    setOpenOnLoad(true)
+    if(triggerDelay && triggerDelay > 0) {
+      setTimeout(()=> {
+        dispatch({ type: 'OPEN_MODAL' })
+        setOpenOnLoad(true)
+      },triggerDelay)
+    } else {
+      dispatch({ type: 'OPEN_MODAL' })
+      setOpenOnLoad(true)
+    }
+
   }, [trigger, dispatch, openOnLoad])
 
   const handleModalOpen = (e: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
Added triggerDelay prop to delay the trigger of Modal content for some time (time in milliseconds, not useful in case of 'click' trigger). Added enum for trigger prop in order to make the same thing done with 'load-session' but using the localStorage.

#### What problem is this solving?

This solves the problem of using the VTEX modal-layout block to display an automatic popup for example that will be shown only if it has not been shown yet. Adding the feature already existing for sessionStorage to the localStorage we prevent the case in which changing tab of the modal is shown again.
Regarding the triggerDelay it can be useful to not show Modal content immediately but after some time.

#### How to test it?

Actually going to the workspace page mentioned above the modal should be triggered after 5 seconds, and a value will be set on localStorage in order to not show again the modal if a value is set in localStorage.

[Workspace](https://testnewslettertheme--reply.myvtex.com/test-newsletter-page)
