### PR TITLE
Add aria-label to modal trigger and add french translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Aria-label to modal trigger.
+- French translations.
+
 ### Changed
 
 - Update GitHub actions/cache to v4

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,6 @@
 {
   "store/modal-layout.close-button.default-label": "Cancel",
+  "store/modal-layout.modal-trigger.aria-label": "Open modal",
   "admin/editor.modal-layout.close-button.title": "Close Modal Button",
   "admin/editor.modal-layout.close-button.label.title": "Button label",
   "admin/editor.modal-layout.close-button.label.description": "E.g \"Close Modal\""

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,7 +1,7 @@
 {
     "store/modal-layout.close-button.default-label": "Annuler",
-    "store/modal-layout.modal-trigger.aria-label": "Modal ouvert",
-    "admin/editor.modal-layout.close-button.title": "Fermer le bouton modal",
-    "admin/editor.modal-layout.close-button.label.title": "Etiquette du bouton",
-    "admin/editor.modal-layout.close-button.label.description": "E.g \"Fermer la modale\""
+    "store/modal-layout.modal-trigger.aria-label": "Ouvrir le modal",
+    "admin/editor.modal-layout.close-button.title": "Bouton de fermeture du modal",
+    "admin/editor.modal-layout.close-button.label.title": "Étiquette du bouton",
+    "admin/editor.modal-layout.close-button.label.description": "Par exemple « Fermer le modal »"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,0 +1,7 @@
+{
+    "store/modal-layout.close-button.default-label": "Annuler",
+    "store/modal-layout.modal-trigger.aria-label": "Modal ouvert",
+    "admin/editor.modal-layout.close-button.title": "Fermer le bouton modal",
+    "admin/editor.modal-layout.close-button.label.title": "Etiquette du bouton",
+    "admin/editor.modal-layout.close-button.label.description": "E.g \"Fermer la modale\""
+}

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -90,7 +90,10 @@ function ModalTrigger(props: Props) {
       <div
         tabIndex={0}
         role="button"
-        aria-label={intl.formatMessage({ id: 'store/modal-layout.modal-trigger.aria-label', defaultMessage: 'Open modal' }) }
+        aria-label={intl.formatMessage({
+          id: 'store/modal-layout.modal-trigger.aria-label',
+          defaultMessage: 'Open modal'
+        })}
         onKeyDown={handleKeyDown}
         onClick={handleModalOpen}
         className={`${handles.triggerContainer} bg-transparent pa0 bw0 dib`}

--- a/react/ModalTrigger.tsx
+++ b/react/ModalTrigger.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
+import { useIntl } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
 import { usePixelEventCallback } from 'vtex.pixel-manager'
@@ -31,6 +32,7 @@ function ModalTrigger(props: Props) {
     classes,
   } = props
 
+  const intl = useIntl()
   const dispatch = useModalDispatch()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
   const [openOnLoad, setOpenOnLoad] = useState(false)
@@ -88,6 +90,7 @@ function ModalTrigger(props: Props) {
       <div
         tabIndex={0}
         role="button"
+        aria-label={intl.formatMessage({ id: 'store/modal-layout.modal-trigger.aria-label', defaultMessage: 'Open modal' }) }
         onKeyDown={handleKeyDown}
         onClick={handleModalOpen}
         className={`${handles.triggerContainer} bg-transparent pa0 bw0 dib`}


### PR DESCRIPTION
#### What problem is this solving?

Fixes accessibility issue with modal trigger button needing a label.

#### How to test it?

Inspect modal trigger button element.

[Workspace](https://ailbhevtexpr--colprofr.myvtex.com/?)

#### Screenshots or example usage:

<img width="1600" height="762" alt="Screenshot 2025-08-18 at 15 59 06" src="https://github.com/user-attachments/assets/1c232830-81e2-40f9-b306-db34da8c77d4" />
